### PR TITLE
Adding required notation for the notes form

### DIFF
--- a/src/Template/Notes/add.ctp
+++ b/src/Template/Notes/add.ctp
@@ -10,10 +10,10 @@
                 <div class="panel-body">
                     <div class="row">
                         <div class="col-xs-12 col-md-6">
-                            <?= $this->Form->input('type', ['options' => $types, 'empty' => true]); ?>
+                            <?= $this->Form->input('type', ['options' => $types, 'empty' => true, 'required' => true, 'label' => ['class' => 'control-label']]); ?>
                         </div>
                         <div class="col-xs-12 col-md-6">
-                            <?= $this->Form->input('shared', ['options' => $shared, 'empty' => true]); ?>
+                            <?= $this->Form->input('shared', ['options' => $shared, 'empty' => true, 'required' => true, 'label' => ['class' => 'control-label']]); ?>
                         </div>
                         <div class="col-xs-12">
                             <?= $this->Form->input('content'); ?>

--- a/src/Template/Notes/edit.ctp
+++ b/src/Template/Notes/edit.ctp
@@ -10,10 +10,10 @@
                 <div class="panel-body">
                     <div class="row">
                         <div class="col-xs-12 col-md-6">
-                            <?= $this->Form->input('type', ['options' => $types]); ?>
+                            <?= $this->Form->input('type', ['options' => $types, 'required' => true, 'label' => ['class' => 'control-label']]); ?>
                         </div>
                         <div class="col-xs-12 col-md-6">
-                            <?= $this->Form->input('shared', ['options' => $shared]); ?>
+                            <?= $this->Form->input('shared', ['options' => $shared, 'required' => true, 'label' => ['class' => 'control-label']]); ?>
                         </div>
                     </div>
                     <div class="row">


### PR DESCRIPTION
Adding visual emphasis on "required" fields for the notes. 
Qobo-admin panel adds asterisk and colors it as per custom.css stylesheet.