### PR TITLE
Differentiate Public and Private notes with icons

### DIFF
--- a/src/Template/Cell/Notes/record_notes.ctp
+++ b/src/Template/Cell/Notes/record_notes.ctp
@@ -2,7 +2,7 @@
     <div class="col-xs-12">
         <div class="text-right add-new-note">
             <?= $this->Html->link(
-                '<span class="glyphicon glyphicon-plus" aria-hidden="true"></span>',
+                '<span class="fa fa-plus" aria-hidden="true"></span>',
                 '#collapseNotesForm',
                 [
                     'title' => __('Add a new Note'),
@@ -27,7 +27,7 @@
                         ];
                     }
                     ?>
-                    <div class="form-group">
+                    <div class="form-group note-colors">
                         <?= $this->Form->radio('type', $typeOptions, [
                                 'escape' => false,
                                 'label' => false,
@@ -37,12 +37,12 @@
                     </div>
                     <?php
                         $sharedOptions = [];
-                    foreach ($shared as $value => $label) {
-                        $sharedOptions[] = [
-                            'value' => $value,
-                            'text' => $label
-                        ];
-                    }
+                        foreach ($shared as $value => $label) {
+                            $sharedOptions[] = [
+                                'value' => $value,
+                                'text' => $label
+                            ];
+                        }
                     ?>
                     <div class="form-group">
                         <?= $this->Form->radio('shared', $sharedOptions, [

--- a/src/Template/Cell/Notes/record_notes.ctp
+++ b/src/Template/Cell/Notes/record_notes.ctp
@@ -37,12 +37,12 @@
                     </div>
                     <?php
                         $sharedOptions = [];
-                        foreach ($shared as $value => $label) {
-                            $sharedOptions[] = [
-                                'value' => $value,
-                                'text' => $label
-                            ];
-                        }
+                    foreach ($shared as $value => $label) {
+                        $sharedOptions[] = [
+                            'value' => $value,
+                            'text' => $label
+                        ];
+                    }
                     ?>
                     <div class="form-group">
                         <?= $this->Form->radio('shared', $sharedOptions, [

--- a/src/Template/Element/record_notes.ctp
+++ b/src/Template/Element/record_notes.ctp
@@ -35,7 +35,7 @@ if (isset($notesView)) {
     <div class="col-xs-<?= $xsColWidth ?> col-sm-<?= $smColWidth ?> col-md-<?= $mdColWidth ?> col-lg-<?= $lgColWidth ?>">
         <div class="panel panel-<?= $note->type ?> note">
             <div class="panel-heading">
-                <span class="fa <?= ( ($note->shared === 'public') ? 'fa-user' : 'fa-user-secret') ?>" aria-hidden="true"></span>
+                <span class="fa <?= ( ($note->shared === 'public') ? 'fa-unlock' : 'fa-lock') ?>" aria-hidden="true"></span>
                 <strong><?= $note->user->username ?></strong>
                 <span class="actions">
                     <?php if ($this->request->session()->read('Auth.User.id') === $note->user_id) : ?>

--- a/src/Template/Element/record_notes.ctp
+++ b/src/Template/Element/record_notes.ctp
@@ -35,7 +35,7 @@ if (isset($notesView)) {
     <div class="col-xs-<?= $xsColWidth ?> col-sm-<?= $smColWidth ?> col-md-<?= $mdColWidth ?> col-lg-<?= $lgColWidth ?>">
         <div class="panel panel-<?= $note->type ?> note">
             <div class="panel-heading">
-                <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+                <span class="fa <?= ( ($note->shared === 'public') ? 'fa-user' : 'fa-user-secret') ?>" aria-hidden="true"></span>
                 <strong><?= $note->user->username ?></strong>
                 <span class="actions">
                     <?php if ($this->request->session()->read('Auth.User.id') === $note->user_id) : ?>
@@ -46,7 +46,7 @@ if (isset($notesView)) {
                         $note->id
                     ], [
                         'title' => __('Edit'),
-                        'class' => 'glyphicon glyphicon-pencil'
+                        'class' => 'fa fa-pencil'
                     ]) ?>
                     <?= $this->Form->postLink('', [
                         'plugin' => 'notes',
@@ -56,7 +56,7 @@ if (isset($notesView)) {
                     ], [
                         'confirm' => __('Are you sure you want to delete # {0}?', $note->id),
                         'title' => __('Delete'),
-                        'class' => 'glyphicon glyphicon-trash'
+                        'class' => 'fa fa-trash'
                     ]) ?>
                     <?php endif; ?>
                 </span>
@@ -86,7 +86,7 @@ if (isset($notesView)) {
                 ?>
                 <?php if (!empty($relatedLink)) : ?>
                 <a href="<?= $relatedLink['url']; ?>">
-                    <span class="glyphicon glyphicon-link" aria-hidden="true"></span> <?= $relatedLink['title']; ?>
+                    <span class="fa fa-link" aria-hidden="true"></span> <?= $relatedLink['title']; ?>
                 </a>
                 <?php else : ?>
                     &nbsp;

--- a/webroot/css/notes.css
+++ b/webroot/css/notes.css
@@ -1,3 +1,7 @@
+.note-colors .radio-inline {
+    height: 25px;
+    width: 30px;
+}
 .add-new-note {
     margin-bottom: 15px;
 }


### PR DESCRIPTION
* To differentiate notes type, bootstrap glyphicons are replaced with font-awesome icons, that have bigger variety of icons. 
* Aligned note color types, to be shown horizontally.