### PR TITLE
Fix for PHP notice on username rendering (task #5955)

### DIFF
--- a/config/Migrations/20180515114128_AddRelatedIdRelatedModelIndexToNotes.php
+++ b/config/Migrations/20180515114128_AddRelatedIdRelatedModelIndexToNotes.php
@@ -1,0 +1,25 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddRelatedIdRelatedModelIndexToNotes extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('notes');
+
+        // Add index
+        $table->addIndex(
+            ['related_id', 'related_model'],
+            ['name' => 'BY_RELATED_ID_AND_RELATED_MODEL', 'unique' => false]
+        );
+
+        $table->update();
+    }
+}

--- a/src/Template/Element/Notes/boxes.ctp
+++ b/src/Template/Element/Notes/boxes.ctp
@@ -36,7 +36,7 @@ if ($inPluginView) {
         <div class="box box-<?= $note->type ?> box-solid note">
             <div class="box-header with-border">
                 <span class="fa fa-<?= $shared[$note->shared]['icon'] ?>" aria-hidden="true" title="<?= $shared[$note->shared]['label'] ?>"></span>
-                <strong title="Author"><?= $note->user->username ?></strong>
+                <strong title="Author"><?= $note->get('user') ? $note->get('user')->get('username') : '' ?></strong>
                 <span class="actions pull-right">
                     <?php if ($this->request->session()->read('Auth.User.id') === $note->user_id) : ?>
                     <?= $this->Html->link('', [

--- a/src/View/Cell/NotesCell.php
+++ b/src/View/Cell/NotesCell.php
@@ -45,22 +45,12 @@ class NotesCell extends Cell
         $types = $this->Notes->getTypes();
         $shared = $this->Notes->getShared();
         $notes = $this->Notes->find('all')
-            ->contain([
-                'Users'
-            ])
-            ->where([
-                'Notes.user_id' => $currentUser['id']
-            ])
-            ->orWhere([
-                'Notes.shared' => $this->Notes->getPublicShared()
-            ])
-            ->andWhere([
-                'Notes.related_model' => $relatedModel,
-                'Notes.related_id' => $relatedId
-            ])
-            ->order([
-                'Notes.modified' => 'DESC'
-            ])->all();
+            ->contain(['Users'])
+            ->where(['Notes.user_id' => $currentUser['id']])
+            ->orWhere(['Notes.shared' => $this->Notes->getPublicShared()])
+            ->andWhere(['Notes.related_model' => $relatedModel, 'Notes.related_id' => $relatedId])
+            ->order(['Notes.modified' => 'DESC'])
+            ->all();
 
         $this->set(compact('relatedModel', 'relatedId', 'types', 'shared', 'notes'));
     }


### PR DESCRIPTION
* Display username only if user entity is provided.
* Added index for `related_id` and `related_model` columns for performance optimization.