### PR TITLE
Prefixing plugins table with 'qobo_' (task #5662)

### DIFF
--- a/config/Migrations/20180516083209_AlterTableNotes.php
+++ b/config/Migrations/20180516083209_AlterTableNotes.php
@@ -1,0 +1,18 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AlterTableNotes extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('notes')
+            ->rename('qobo_notes');
+    }
+}

--- a/src/Model/Table/NotesTable.php
+++ b/src/Model/Table/NotesTable.php
@@ -74,7 +74,7 @@ class NotesTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('notes');
+        $this->table('qobo_notes');
         $this->primaryKey('id');
 
         $this->addBehavior('Timestamp');

--- a/tests/Fixture/NotesFixture.php
+++ b/tests/Fixture/NotesFixture.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class NotesFixture extends TestFixture
 {
-
+    public $table = 'qobo_notes';
     /**
      * Fields
      *

--- a/tests/TestCase/Controller/NotesControllerTest.php
+++ b/tests/TestCase/Controller/NotesControllerTest.php
@@ -112,7 +112,7 @@ class NotesControllerTest extends IntegrationTestCase
         $this->assertResponseSuccess();
 
         // fetch modified record
-        $entity = TableRegistry::get('Notes')->get($id);
+        $entity = $this->NotesTable->get($id);
         $this->assertEquals($data['shared'], $entity->shared);
     }
 


### PR DESCRIPTION
- Adding `qobo_` prefix to plugin tables.
- Fixing TableRegistry typo in unit test.