### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,25 +16,39 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,57 @@
 {
     "name": "qobo/cakephp-notes",
     "description": "Notes plugin for CakePHP",
+    "keywords": ["cakephp", "notes"],
     "type": "cakephp-plugin",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Qobo Ltd",
-			"email": "info@qobo.biz",
-			"homepage": "https://www.qobo.biz",
-			"role": "Developer"
-		}
-	],
+    "license": "MIT",
+    "homepage": "https://www.qobo.biz",
+    "authors": [
+        {
+            "name": "Qobo Ltd",
+            "email": "support@qobo.biz",
+            "homepage": "https://www.qobo.biz",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-notes/issues",
+        "source": "https://github.com/QoboLtd/cakephp-notes"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0"
+        "qobo/cakephp-utils": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "Notes\\": "src"
+            "Notes\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Notes\\Test\\": "tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "Notes\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,5 +28,12 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
+
+    <!-- Ignore files -->
+    <arg name="ignore" value="config/Migrations/" />
+
+    <!-- Ignore minified files -->
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="notes">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Notes Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/NotesController.php
+++ b/src/Controller/NotesController.php
@@ -114,7 +114,7 @@ class NotesController extends AppController
      * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function edit($id = null)
+    public function edit(string $id = null)
     {
         $note = $this->Notes->get($id, [
             'contain' => []
@@ -149,7 +149,7 @@ class NotesController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
         $note = $this->Notes->get($id);

--- a/src/Controller/NotesController.php
+++ b/src/Controller/NotesController.php
@@ -11,7 +11,7 @@
  */
 namespace Notes\Controller;
 
-use Cake\Network\Exception\UnauthorizedException;
+use Cake\Http\Exception\UnauthorizedException;
 use Notes\Controller\AppController;
 
 /**
@@ -79,7 +79,7 @@ class NotesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Network\Response|void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -111,8 +111,8 @@ class NotesController extends AppController
      * Edit method
      *
      * @param string|null $id Note id.
-     * @return \Cake\Network\Response|void Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
+     * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)
     {
@@ -146,7 +146,7 @@ class NotesController extends AppController
      * Delete method
      *
      * @param string|null $id Note id.
-     * @return \Cake\Network\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/src/Model/Table/NotesTable.php
+++ b/src/Model/Table/NotesTable.php
@@ -74,8 +74,8 @@ class NotesTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('qobo_notes');
-        $this->primaryKey('id');
+        $this->setTable('qobo_notes');
+        $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Muffin/Trash.Trash');

--- a/src/Model/Table/NotesTable.php
+++ b/src/Model/Table/NotesTable.php
@@ -141,9 +141,9 @@ class NotesTable extends Table
     /**
      * Returns Notes types.
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getTypes()
+    public function getTypes(): array
     {
         return $this->types;
     }
@@ -151,9 +151,9 @@ class NotesTable extends Table
     /**
      * Returns Notes shared options.
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getShared()
+    public function getShared(): array
     {
         return $this->shared;
     }
@@ -163,7 +163,7 @@ class NotesTable extends Table
      *
      * @return string
      */
-    public function getPublicShared()
+    public function getPublicShared(): string
     {
         return static::SHARED_PUBLIC;
     }
@@ -173,7 +173,7 @@ class NotesTable extends Table
      *
      * @return string
      */
-    public function getPrivateShared()
+    public function getPrivateShared(): string
     {
         return static::SHARED_PRIVATE;
     }

--- a/src/Template/Element/Notes/boxes.ctp
+++ b/src/Template/Element/Notes/boxes.ctp
@@ -15,7 +15,7 @@ use Cake\Utility\Inflector;
 
 echo $this->Html->css('Notes.notes', ['block' => 'css']);
 
-$inPluginView = 'Notes' === $this->request->param('plugin');
+$inPluginView = 'Notes' === $this->request->getParam('plugin');
 // set viewport widths
 if ($inPluginView) {
     $viewport = ['lg' => 2, 'md' => 3, 'sm' => 4, 'xs' => 6];
@@ -38,7 +38,7 @@ if ($inPluginView) {
                 <span class="fa fa-<?= $shared[$note->shared]['icon'] ?>" aria-hidden="true" title="<?= $shared[$note->shared]['label'] ?>"></span>
                 <strong title="Author"><?= $note->get('user') ? $note->get('user')->get('username') : '' ?></strong>
                 <span class="actions pull-right">
-                <?php if ($this->request->session()->read('Auth.User.id') === $note->user_id) : ?>
+                <?php if ($this->request->getSession()->read('Auth.User.id') === $note->user_id) : ?>
                     <?= $this->Html->link('', [
                         'plugin' => 'notes',
                         'controller' => 'notes',

--- a/src/Template/Notes/add.ctp
+++ b/src/Template/Notes/add.ctp
@@ -86,7 +86,7 @@ echo $this->Html->scriptBlock(
                             </div>
                         </div>
                     </div>
-                    <?= $this->Form->input('Notes.content', [
+                    <?= $this->Form->control('Notes.content', [
                         'type' => 'textarea',
                         'label' => false,
                         'required' => true,

--- a/src/View/Cell/NotesCell.php
+++ b/src/View/Cell/NotesCell.php
@@ -49,13 +49,22 @@ class NotesCell extends Cell
         $this->loadModel('Notes.Notes');
         $types = $this->Notes->getTypes();
         $shared = $this->Notes->getShared();
+        /**
+         * @var \Cake\ORM\Query $notes
+         */
         $notes = $this->Notes->find('all')
-            ->contain(['Users'])
-            ->where(['Notes.user_id' => $currentUser['id']])
-            ->orWhere(['Notes.shared' => $this->Notes->getPublicShared()])
-            ->andWhere(['Notes.related_model' => $relatedModel, 'Notes.related_id' => $relatedId])
+            ->where([
+                'AND' => [
+                    ['Notes.related_model' => $relatedModel, 'Notes.related_id' => $relatedId],
+                    'OR' => [
+                        ['Notes.user_id' => $currentUser['id']],
+                        ['Notes.shared' => $this->Notes->getPublicShared()]
+                    ]
+                ]
+            ])
             ->order(['Notes.modified' => 'DESC'])
-            ->all();
+            ->contain(['Users']);
+        $notes = $notes->all();
 
         $this->set(compact('relatedModel', 'relatedId', 'types', 'shared', 'notes'));
     }

--- a/src/View/Cell/NotesCell.php
+++ b/src/View/Cell/NotesCell.php
@@ -13,6 +13,11 @@ namespace Notes\View\Cell;
 
 use Cake\View\Cell;
 
+/**
+ * Notes Cell
+ *
+ * @property \Notes\Model\Table\NotesTable $Notes
+ */
 class NotesCell extends Cell
 {
     /**
@@ -22,7 +27,7 @@ class NotesCell extends Cell
      * @param  string $relatedId related record id
      * @return void
      */
-    public function form($relatedModel, $relatedId)
+    public function form(string $relatedModel, string $relatedId): void
     {
         $currentUser = $this->request->session()->read('Auth.User');
         $this->loadModel('Notes.Notes');
@@ -38,7 +43,7 @@ class NotesCell extends Cell
      * @param  string $relatedId related record id
      * @return void
      */
-    public function listing($relatedModel, $relatedId)
+    public function listing(string $relatedModel, string $relatedId): void
     {
         $currentUser = $this->request->session()->read('Auth.User');
         $this->loadModel('Notes.Notes');

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Notes\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,16 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace Notes\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/Controller/NotesControllerTest.php
+++ b/tests/TestCase/Controller/NotesControllerTest.php
@@ -42,7 +42,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->get('/notes/notes');
         $this->assertResponseOk();
@@ -57,7 +57,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $data = [
             'type' => 'success',
@@ -79,7 +79,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testAddWrongData()
+    public function testAddWrongData(): void
     {
         $data = [
             'type' => 'success',
@@ -100,7 +100,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testEdit()
+    public function testEdit(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -121,7 +121,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testEditUnauthorized()
+    public function testEditUnauthorized(): void
     {
         $id = '00000000-0000-0000-0000-000000000003';
 
@@ -139,7 +139,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -157,7 +157,7 @@ class NotesControllerTest extends IntegrationTestCase
      *
      * @return void
      */
-    public function testDeleteUnauthorizedUser()
+    public function testDeleteUnauthorizedUser(): void
     {
         $id = '00000000-0000-0000-0000-000000000003';
         $this->delete('/notes/notes/delete/' . $id);

--- a/tests/TestCase/Controller/NotesControllerTest.php
+++ b/tests/TestCase/Controller/NotesControllerTest.php
@@ -6,6 +6,8 @@ use Cake\TestSuite\IntegrationTestCase;
 
 /**
  * Notes\Controller\NotesController Test Case
+ *
+ * @property \Notes\Model\Table\NotesTable $NotesTable
  */
 class NotesControllerTest extends IntegrationTestCase
 {
@@ -34,7 +36,11 @@ class NotesControllerTest extends IntegrationTestCase
 
         $this->enableRetainFlashMessages();
 
-        $this->NotesTable = TableRegistry::get('Notes.Notes');
+        /**
+         * @var \Notes\Model\Table\NotesTable $table
+         */
+        $table = TableRegistry::get('Notes.Notes');
+        $this->NotesTable = $table;
     }
 
     /**
@@ -111,7 +117,9 @@ class NotesControllerTest extends IntegrationTestCase
         $this->post('/notes/notes/edit/' . $id, $data);
         $this->assertResponseSuccess();
 
-        // fetch modified record
+        /**
+         * @var \Notes\Model\Entity\Note $entity Modified record
+         */
         $entity = $this->NotesTable->get($id);
         $this->assertEquals($data['shared'], $entity->shared);
     }

--- a/tests/TestCase/Controller/NotesControllerTest.php
+++ b/tests/TestCase/Controller/NotesControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Notes\Test\TestCase\Controller;
 
+use Cake\Http\Response;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 
@@ -139,7 +140,10 @@ class NotesControllerTest extends IntegrationTestCase
 
         $this->post('/notes/notes/edit/' . $id, $data);
         $this->assertResponseError();
-        $this->assertSame(401, $this->_response->getStatusCode());
+        $this->assertTrue(is_object($this->_response), "Response is not an object");
+        if ($this->_response instanceof Response) {
+            $this->assertSame(401, $this->_response->getStatusCode());
+        }
     }
 
     /**
@@ -170,6 +174,9 @@ class NotesControllerTest extends IntegrationTestCase
         $id = '00000000-0000-0000-0000-000000000003';
         $this->delete('/notes/notes/delete/' . $id);
         $this->assertResponseError();
-        $this->assertSame(401, $this->_response->getStatusCode());
+        $this->assertTrue(is_object($this->_response), "Response is not an object");
+        if ($this->_response instanceof Response) {
+            $this->assertSame(401, $this->_response->getStatusCode());
+        }
     }
 }

--- a/tests/TestCase/Model/Table/NotesTableTest.php
+++ b/tests/TestCase/Model/Table/NotesTableTest.php
@@ -37,7 +37,11 @@ class NotesTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('Notes') ? [] : ['className' => 'Notes\Model\Table\NotesTable'];
-        $this->Notes = TableRegistry::get('Notes', $config);
+        /**
+         * @var \Notes\Model\Table\NotesTable $notes
+         */
+        $notes = TableRegistry::get('Notes', $config);
+        $this->Notes = $notes;
     }
 
     /**
@@ -81,6 +85,9 @@ class NotesTableTest extends TestCase
         ];
 
         $entity = $this->Notes->newEntity($data);
+        /**
+         * @var \Notes\Model\Entity\Note $result
+         */
         $result = $this->Notes->save($entity);
 
         $this->assertNotEmpty($result->get('id'));

--- a/tests/TestCase/Model/Table/NotesTableTest.php
+++ b/tests/TestCase/Model/Table/NotesTableTest.php
@@ -52,7 +52,7 @@ class NotesTableTest extends TestCase
         parent::tearDown();
     }
 
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $validator = new \Cake\Validation\Validator();
         $result = $this->Notes->validationDefault($validator);
@@ -71,7 +71,7 @@ class NotesTableTest extends TestCase
         $this->assertEmpty($entity->getErrors());
     }
 
-    public function testSave()
+    public function testSave(): void
     {
         $data = [
             'type' => 'success',
@@ -86,7 +86,7 @@ class NotesTableTest extends TestCase
         $this->assertNotEmpty($result->get('id'));
     }
 
-    public function testGetTypes()
+    public function testGetTypes(): void
     {
         $result = $this->Notes->getTypes();
         $this->assertTrue(is_array($result), "getTypes() returns a non-array");
@@ -97,7 +97,7 @@ class NotesTableTest extends TestCase
         $this->assertArrayHasKey('success', $result, "'success' is not in returned types");
     }
 
-    public function testGetShared()
+    public function testGetShared(): void
     {
         $result = $this->Notes->getShared();
         $this->assertTrue(is_array($result), "getShared() returns a non-array");
@@ -106,13 +106,13 @@ class NotesTableTest extends TestCase
         $this->assertArrayHasKey('public', $result, "'Public' is not in returned shared values");
     }
 
-    public function testGetPublicShared()
+    public function testGetPublicShared(): void
     {
         $result = $this->Notes->getPublicShared();
         $this->assertEquals('public', $result);
     }
 
-    public function testGetPrivateShared()
+    public function testGetPrivateShared(): void
     {
         $result = $this->Notes->getPrivateShared();
         $this->assertEquals('private', $result);

--- a/tests/TestCase/Model/Table/NotesTableTest.php
+++ b/tests/TestCase/Model/Table/NotesTableTest.php
@@ -68,7 +68,7 @@ class NotesTableTest extends TestCase
 
         $entity = $this->Notes->newEntity($data);
 
-        $this->assertEmpty($entity->errors());
+        $this->assertEmpty($entity->getErrors());
     }
 
     public function testSave()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,4 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
@@ -9,29 +7,28 @@ if (empty($pluginName)) {
     throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
     throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -108,9 +105,6 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ use Cake\Filesystem\Folder;
 
 $pluginName = 'Notes';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
 $findRoot = function () {
@@ -25,7 +25,7 @@ $findRoot = function () {
         return $root;
     }
 
-    throw new \Exception("Failed to find CakePHP");
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
@@ -83,7 +83,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -93,13 +93,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -5,10 +5,4 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
-/**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();
-
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.0](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.0).
* Updated `composer.json`.
* Fixed all deprecated errors for CakePHP 3.6
* Fixed all PHPStan issues.
* Enabled PHPStan on TravisCI.