### PR TITLE
Fix migrations for CakePHP v3.8

### DIFF
--- a/config/Migrations/20180516083209_AlterTableNotes.php
+++ b/config/Migrations/20180516083209_AlterTableNotes.php
@@ -12,7 +12,9 @@ class AlterTableNotes extends AbstractMigration
      */
     public function change()
     {
-        $this->table('notes')
-            ->rename('qobo_notes');
+        $this
+            ->table('notes')
+            ->rename('qobo_notes')
+            ->save();
     }
 }


### PR DESCRIPTION
We adjust the migrations so that work with CakePHP v3.8

